### PR TITLE
3157 use enum labels in current filters search status

### DIFF
--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -19,8 +19,10 @@ module ActiveAdmin
         condition_values = condition.values.map(&:value)
         if related_class
           related_class.where(related_primary_key => condition_values)
-        elsif enum_attribute && enum_attribute.values.first&.is_a?(Integer)
-          enum_attribute.invert.slice(*condition_values.map(&:to_i)).values
+        elsif custom_filter_collection && custom_filter_collection.is_a?(Hash)
+          custom_filter_collection.invert.transform_keys(&:to_s).slice(*condition_values).values
+        elsif enum_attribute
+          enum_attribute.invert.transform_keys(&:to_s).slice(*condition_values).values
         else
           condition_values
         end
@@ -116,6 +118,10 @@ module ActiveAdmin
 
       def enum_attribute
         resource_class.defined_enums[name]
+      end
+
+      def custom_filter_collection
+        resource.filters.dig(name.to_sym, :collection)
       end
     end
   end

--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -19,6 +19,8 @@ module ActiveAdmin
         condition_values = condition.values.map(&:value)
         if related_class
           related_class.where(related_primary_key => condition_values)
+        elsif enum_attribute && enum_attribute.values.first&.is_a?(Integer)
+          enum_attribute.invert.slice(*condition_values.map(&:to_i)).values
         else
           condition_values
         end
@@ -110,6 +112,10 @@ module ActiveAdmin
         condition_attribute.klass.reflect_on_all_associations.
           reject { |r| r.options[:polymorphic] }. #skip polymorphic
           detect { |r| r.foreign_key.to_s == name.to_s }
+      end
+
+      def enum_attribute
+        resource_class.defined_enums[name]
       end
     end
   end

--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -19,6 +19,8 @@ module ActiveAdmin
         condition_values = condition.values.map(&:value)
         if related_class
           related_class.where(related_primary_key => condition_values)
+        elsif custom_filter_collection && custom_filter_collection.is_a?(Array) && custom_filter_collection.all?(Array)
+          custom_filter_collection.to_h.invert.transform_keys(&:to_s).slice(*condition_values).values
         elsif custom_filter_collection && custom_filter_collection.is_a?(Hash)
           custom_filter_collection.invert.transform_keys(&:to_s).slice(*condition_values).values
         elsif enum_attribute

--- a/lib/active_admin/filters/active_filter.rb
+++ b/lib/active_admin/filters/active_filter.rb
@@ -20,11 +20,11 @@ module ActiveAdmin
         if related_class
           related_class.where(related_primary_key => condition_values)
         elsif custom_filter_collection && custom_filter_collection.is_a?(Array) && custom_filter_collection.all?(Array)
-          custom_filter_collection.to_h.invert.transform_keys(&:to_s).slice(*condition_values).values
+          hash_lookup_by_values(custom_filter_collection.to_h, condition_values)
         elsif custom_filter_collection && custom_filter_collection.is_a?(Hash)
-          custom_filter_collection.invert.transform_keys(&:to_s).slice(*condition_values).values
+          hash_lookup_by_values(custom_filter_collection, condition_values)
         elsif enum_attribute
-          enum_attribute.invert.transform_keys(&:to_s).slice(*condition_values).values
+          hash_lookup_by_values(enum_attribute, condition_values)
         else
           condition_values
         end
@@ -124,6 +124,14 @@ module ActiveAdmin
 
       def custom_filter_collection
         resource.filters.dig(name.to_sym, :collection)
+      end
+
+      def hash_lookup_by_values(hash, condition_values)
+        condition_values.map do |value|
+          # value(filter form's search params) will be a string,
+          # so let us transform the lookup object (e.g. for integer backed enums)
+          (hash.transform_values(&:to_s).key(value) || value).to_s.humanize
+        end
       end
     end
   end

--- a/spec/support/templates/admin/stores.rb
+++ b/spec/support/templates/admin/stores.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 ActiveAdmin.register Store do
-  permit_params :name
+  permit_params :name, :review_status, :reject_reason
 
   index pagination_total: false
 end

--- a/spec/support/templates/admin/stores.rb
+++ b/spec/support/templates/admin/stores.rb
@@ -2,5 +2,9 @@
 ActiveAdmin.register Store do
   permit_params :name, :review_status, :reject_reason
 
+  preserve_default_filters!
+  filter :review_status, as: :select, collection: config.resource_class.review_statuses, multiple: true
+  filter :reject_reason, as: :select, collection: config.resource_class.reject_reasons
+
   index pagination_total: false
 end

--- a/spec/support/templates/migrations/create_stores.tt
+++ b/spec/support/templates/migrations/create_stores.tt
@@ -3,6 +3,8 @@ class CreateStores < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Ra
     create_table :stores do |t|
       t.string :name
       t.integer :user_id
+      t.integer :review_status
+      t.integer :reject_reason
       t.datetime :created_at
       t.datetime :updated_at
     end

--- a/spec/support/templates/models/store.rb
+++ b/spec/support/templates/models/store.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Store < ApplicationRecord
-  enum review_status: [:pending, :approved, :rejected]
-  enum reject_reason: {
+  enum :review_status, [:pending, :approved, :rejected]
+  enum :reject_reason, {
     not_a_good_fit: 0,
     other: 10
   }

--- a/spec/support/templates/models/store.rb
+++ b/spec/support/templates/models/store.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Store < ApplicationRecord
-  enum :review_status, [:pending, :approved, :rejected]
+  enum review_status: [:pending, :approved, :rejected]
   enum reject_reason: {
     not_a_good_fit: 0,
     other: 10

--- a/spec/support/templates/models/store.rb
+++ b/spec/support/templates/models/store.rb
@@ -1,3 +1,8 @@
 # frozen_string_literal: true
 class Store < ApplicationRecord
+  enum :review_status, [:pending, :approved, :rejected]
+  enum reject_reason: {
+    not_a_good_fit: 0,
+    other: 10
+  }
 end

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -276,11 +276,11 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
     end
 
     context 'with custom array collection for filter options' do
-        let(:resource) do
-          namespace.register(resource_klass) do
-            filter :reject_reason, as: :select, collection: [[:not_a_good_fit, '0'], ["\u274c Vetoed", '10']]
-          end
+      let(:resource) do
+        namespace.register(resource_klass) do
+          filter :reject_reason, as: :select, collection: [[:not_a_good_fit, '0'], ["\u274c Vetoed", '10']]
         end
+      end
       let(:search) do
         resource_klass.ransack(reject_reason_eq: '10')
       end
@@ -291,17 +291,33 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
     end
 
     context 'with custom hash collection for filter options' do
-        let(:resource) do
-          namespace.register(resource_klass) do
-            filter :reject_reason, as: :select, collection: { requirements_not_met: 0, "\u274c Vetoed" => 10 }
-          end
+      let(:resource) do
+        namespace.register(resource_klass) do
+          filter :reject_reason, as: :select, collection: { requirements_not_met: 0, "\u274c Vetoed" => 10 }
         end
+      end
       let(:search) do
         resource_klass.ransack(reject_reason_eq: '0')
       end
 
       it "should use the queried value as a fallback, even if the lookup failed" do
         expect(subject.values.first).to eq :requirements_not_met.to_s.humanize
+      end
+    end
+
+    context 'filtering by multiple selections' do
+      let(:resource) do
+        namespace.register(resource_klass) do
+          filter :reject_reason, as: :select, collection: { requirements_not_met: 0, "\u274c Vetoed" => 10 }
+        end
+      end
+      let(:search) do
+        resource_klass.ransack(reject_reason_in: ['0','10'])
+      end
+
+      it "should use the queried value as a fallback, even if the lookup failed" do
+        expect(subject.values.first).to eq :requirements_not_met.to_s.humanize
+        expect(subject.values.second).to eq "\u274c Vetoed".to_s.humanize
       end
     end
   end

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -255,34 +255,34 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
     end
   end
 
-  describe "Enum values" do
+  describe "Enum values in current search status view" do
     enum_attributes = Store.defined_enums
-    let(:resource_klass){ Store }
+    let(:resource_klass) { Store }
     let(:resource) do
       namespace.register(resource_klass)
     end
     enum_attributes.each do |enum_attribute, enum_options|
       enum_options.each do |enum_label, enum_value|
-        context 'in current search status view' do
+        context "with no custom collection provided as filter options" do
           let(:search) do
             resource_klass.ransack("#{enum_attribute}_eq" => enum_value.to_s)
           end
 
-          it "should use the enum label instead of the database value" do
+          it "should use the enum label from enum definition instead of the database value" do
             expect(subject.values.first).to eq enum_label.to_s.humanize
           end
         end
       end
     end
 
-    context 'with custom array collection for filter options' do
+    context "with custom array collection for filter options" do
       let(:resource) do
         namespace.register(resource_klass) do
-          filter :reject_reason, as: :select, collection: [[:not_a_good_fit, '0'], ["\u274c Vetoed", '10']]
+          filter :reject_reason, as: :select, collection: [[:not_a_good_fit, "0"], ["\u274c Vetoed", "10"]]
         end
       end
       let(:search) do
-        resource_klass.ransack(reject_reason_eq: '10')
+        resource_klass.ransack(reject_reason_eq: "10")
       end
 
       it "should use the collection label instead of the database value" do
@@ -290,14 +290,14 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
       end
     end
 
-    context 'with custom hash collection for filter options' do
+    context "with custom hash collection for filter options" do
       let(:resource) do
         namespace.register(resource_klass) do
           filter :reject_reason, as: :select, collection: { requirements_not_met: 0, "\u274c Vetoed" => 10 }
         end
       end
       let(:search) do
-        resource_klass.ransack(reject_reason_eq: '0')
+        resource_klass.ransack(reject_reason_eq: "0")
       end
 
       it "should use the queried value as a fallback, even if the lookup failed" do
@@ -305,17 +305,17 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
       end
     end
 
-    context 'filtering by multiple selections' do
+    context "filtering by multiple selections" do
       let(:resource) do
         namespace.register(resource_klass) do
           filter :reject_reason, as: :select, collection: { requirements_not_met: 0, "\u274c Vetoed" => 10 }
         end
       end
       let(:search) do
-        resource_klass.ransack(reject_reason_in: ['0','10'])
+        resource_klass.ransack(reject_reason_in: ["0", "10"])
       end
 
-      it "should use the queried value as a fallback, even if the lookup failed" do
+      it "should perform label lookups for multiple items, in case of multiple selections" do
         expect(subject.values.first).to eq :requirements_not_met.to_s.humanize
         expect(subject.values.second).to eq "\u274c Vetoed".to_s.humanize
       end

--- a/spec/unit/filters/active_filter_spec.rb
+++ b/spec/unit/filters/active_filter_spec.rb
@@ -254,4 +254,55 @@ RSpec.describe ActiveAdmin::Filters::ActiveFilter do
       expect(subject.values.first).to eq user
     end
   end
+
+  describe "Enum values" do
+    enum_attributes = Store.defined_enums
+    let(:resource_klass){ Store }
+    let(:resource) do
+      namespace.register(resource_klass)
+    end
+    enum_attributes.each do |enum_attribute, enum_options|
+      enum_options.each do |enum_label, enum_value|
+        context 'in current search status view' do
+          let(:search) do
+            resource_klass.ransack("#{enum_attribute}_eq" => enum_value.to_s)
+          end
+
+          it "should use the enum label instead of the database value" do
+            expect(subject.values.first).to eq enum_label.to_s.humanize
+          end
+        end
+      end
+    end
+
+    context 'with custom array collection for filter options' do
+        let(:resource) do
+          namespace.register(resource_klass) do
+            filter :reject_reason, as: :select, collection: [[:not_a_good_fit, '0'], ["\u274c Vetoed", '10']]
+          end
+        end
+      let(:search) do
+        resource_klass.ransack(reject_reason_eq: '10')
+      end
+
+      it "should use the collection label instead of the database value" do
+        expect(subject.values.first).to eq "\u274c Vetoed".humanize
+      end
+    end
+
+    context 'with custom hash collection for filter options' do
+        let(:resource) do
+          namespace.register(resource_klass) do
+            filter :reject_reason, as: :select, collection: { requirements_not_met: 0, "\u274c Vetoed" => 10 }
+          end
+        end
+      let(:search) do
+        resource_klass.ransack(reject_reason_eq: '0')
+      end
+
+      it "should use the queried value as a fallback, even if the lookup failed" do
+        expect(subject.values.first).to eq :requirements_not_met.to_s.humanize
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes Issue #3157 - Display Enum labels for Active Filters in Current Search Status 

ActiveAdmin::Filters::ActiveFilter#values controls the displayed value for active filters.
This currently does not have any special handling for Enums.

For e.g. with an enum definition like `enum status: [:inactive, :active] `, when filtering for :inactive status, the Current Search Status widget shows "Status is **0**"

This PR, uses ActiveRecord::Enum.defined_enums to translate the display value for the filter to the associated label for enums. The Current Search Status widget will now show "Status is **Inactive**"

If a custom collection is provided when registering the ActiveAdmin resource e.g. `filter :status, as: :select, collection: [[:not_active, 0], [:active, 1]]` which specifies dropdown labels that are different from the enum labels, then the dropdown label from the custom collection is used. The Current Search Status widget will now show "Status is **Not Active**"